### PR TITLE
Add handling for models that don't fit into the GPUs memory

### DIFF
--- a/bench/bench.py
+++ b/bench/bench.py
@@ -57,7 +57,7 @@ def download_model(model_name="medium"):
         whisper.load_model(model_name)
         print(f"'{model_name}' model loaded...")
         return True
-    except:
+    except Exception:
         print(f"'{model_name}' model not available for this device.")
         return False
 

--- a/bench/bench.py
+++ b/bench/bench.py
@@ -140,6 +140,9 @@ def cli():
 
     print("Available models on this hardware: ", available_models)
 
+    # set that hold all models that weren't able to load or failed for other reasons
+    not_available_or_failed_set = set(model_names).difference(set(available_models))
+
     results: list[dict] = []  # list with model timings that worked
     failed_models: list[str] = []  # list with model_names that failed to load
     for model in available_models:
@@ -148,8 +151,9 @@ def cli():
         model_times = benchmark_model(model)
         # only add models to result that actually worked
         # keep track over which models failed
+        print(model_times)
         if model_times is None:
-            failed_models.append(model)
+            not_available_or_failed_set.add(model)
             continue
 
         model_results = {
@@ -167,7 +171,7 @@ def cli():
     output = {
         "system_info": system_info,
         "results": results,
-        "failed_models": failed_models
+        "failed_models": list(not_available_or_failed_set)
     }
 
     print(json.dumps(output, indent=4))

--- a/bench/bench.py
+++ b/bench/bench.py
@@ -52,13 +52,13 @@ def download_model(model_name="medium"):
     # not all models are available for all devices!
     # especially the large model is not available for smaller gpu's
 
-    print("Trying to download and load " + model_name + " model...")
+    print(f"Trying to download and load '{model_name}' model...")
     try:
         whisper.load_model(model_name)
-        print(model_name + " model loaded...")
+        print(f"'{model_name}' model loaded...")
         return True
     except:
-        print(model_name + " model not available for this device.")
+        print(f"'{model_name}' model not available for this device.")
         return False
 
 
@@ -72,7 +72,7 @@ def benchmark_model(model_name="medium") -> Optional[tuple[float, float, float]]
         (model loading time, short transcription time, long transcription time) if model could be loaded, else None
     """
 
-    print("Benchmarking loading time for " + model_name + " model...")
+    print(f"Benchmarking loading time for '{model_name}' model...")
     start_load_time = time.time()
     try:
         model = whisper.load_model(model_name, in_memory=True)
@@ -81,42 +81,27 @@ def benchmark_model(model_name="medium") -> Optional[tuple[float, float, float]]
         return
 
     end_load_time = time.time()
-    print(
-        "Loading time for " + model_name + " model: ", end_load_time - start_load_time
-    )
+    model_load_time = end_load_time - start_load_time
+    print(f"Loading time for '{model_name}' model: {model_load_time}")
 
     # benchmark short audio file
-    print(
-        "Benchmarking transcription time (short audio file) for "
-        + model_name
-        + " model..."
-    )
+    print(f"Benchmarking transcription time (short audio file) for '{model_name}' model...")
     start_transcribe_time = time.time()
     model.transcribe("test_files/En-Open_Source_Software_CD-article.ogg", language="EN")
     end_transcribe_time = time.time()
-    print(
-        "Transcription time (short audio file) for " + model_name + " model: ",
-        end_transcribe_time - start_transcribe_time,
-    )
     short_audio_file_transcription_time = end_transcribe_time - start_transcribe_time
+    print(f"Transcription time (short audio file) for '{model_name}' model: {short_audio_file_transcription_time}")
 
     # benchmark long audio file
-    print(
-        "Benchmarking transcription time (long audio file) for "
-        + model_name
-        + " model..."
-    )
+    print(f"Benchmarking transcription time (long audio file) for '{model_name}' model...")
     start_transcribe_time = time.time()
     model.transcribe("test_files/A_Time_for_Choosing.ogg", language="EN")
     end_transcribe_time = time.time()
-    print(
-        "Transcription time (long audio file) for " + model_name + " model: ",
-        end_transcribe_time - start_transcribe_time,
-    )
     long_audio_file_transcription_time = end_transcribe_time - start_transcribe_time
+    print(f"Transcription time (long audio file) for '{model_name}' model: {long_audio_file_transcription_time}")
 
     return (
-        end_load_time - start_load_time,
+        model_load_time,
         short_audio_file_transcription_time,
         long_audio_file_transcription_time,
     )


### PR DESCRIPTION
Yeah. The title describes where the main functional improvement lays.

And I adjusted the naming and wording in prints to communicate that downloads will only happen if needed. When the model is present the 'download-function' wont download anything and instead just _load_ from cache. So I renamed things to clarify this.

I also added some other things like using f-strings, because they're cool.
And made one except at least that slim that it won't steamroll OutOfMemorys or KeyboardInterrupts.
